### PR TITLE
Fix dropbox import & update Leaflet CDN

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,8 +33,8 @@
 
 
   <!-- Leaflet -->
-  <link rel="stylesheet" href="https://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
-  <script src="https://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@0.7.7/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@0.7.7/dist/leaflet.js"></script>
   <!-- Leaflet -->
 
   <!-- Nomie Lab Core -->

--- a/src/nomie-lib/nomie-lab-datasource/type_dropbox.js
+++ b/src/nomie-lib/nomie-lab-datasource/type_dropbox.js
@@ -73,7 +73,7 @@ var NomieLabDatasourceDropbox = function(options) {
    * @param  {Function} callback Callback(err, data)
    */
   pub.getEvents = function(options, callback) {
-    callback(null, pvt.data.ticks);
+    callback(null, pvt.data.events);
   }
 
   /**


### PR DESCRIPTION
Looks like at some point the key for the Events array got changed from `ticks` to `events`, which causes no events to be imported.  This PR fixes this issue by updating the key to the new value.  It does not attempt to be backwards-compatible however.