### PR TITLE
add dependencies for gulp and gulp-electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "browser-sync": "^2.8.2",
+    "gulp": "^3.9.1",
+    "gulp-electron": "^0.1.3",
     "gulp-sass": "^2.0.4",
     "ng-annotate": "^1.0.2"
   }


### PR DESCRIPTION
fixes errors regarding missing gulp and gulp-electron when running `gulp serve`

"Local gulp not found" "Try running: npm install gulp"

"Error: Cannot find module 'gulp-electron'"